### PR TITLE
Updated the sample app to alpha4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ gpr.key=<token goes here>
 
 ## Version History
 
-The latest release of the SDK is `0.1.0-alpha3`. Details about the current and past releases can be found below:
+The latest release of the SDK is `0.1.0-alpha4`. Details about the current and past releases can be found below:
 
+- [0.1.0-alpha4](https://github.com/moonsense/moonsense-android-sdk/releases/tag/0.1.0-alpha4)
 - [0.1.0-alpha3](https://github.com/moonsense/moonsense-android-sdk/releases/tag/0.1.0-alpha3)
 - [0.1.0-alpha2](https://github.com/moonsense/moonsense-android-sdk/releases/tag/0.1.0-alpha2)
 
@@ -53,7 +54,7 @@ With the credentials in place your are ready to include the following line to ad
 
 
 ```gradle
-implementation("io.moonsense:android-sdk:0.1.0-alpha3")
+implementation("io.moonsense:android-sdk:0.1.0-alpha4")
 ```
 
 ## Usage

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -8,7 +8,7 @@ object AppConfig {
     const val minSdkVersion = 16
     const val targetSdkVersion = 30
     const val versionCode = 1
-    const val versionName = "0.1.0-alpha3"
+    const val versionName = "0.1.0-alpha4"
     const val buildToolsVersion = "30.0.3"
     const val androidTestInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     const val jvmTarget = "11"


### PR DESCRIPTION
`alpha4` has just been released with support for `client session group id`. This change updates the default version to the latest.